### PR TITLE
Adding support for Actions

### DIFF
--- a/Resilient.Net.Tests/CircuitBreaker/CircuitBreakerTest.cs
+++ b/Resilient.Net.Tests/CircuitBreaker/CircuitBreakerTest.cs
@@ -118,7 +118,7 @@ namespace Resilient.Net.Tests
             }
 
             [Fact]
-            public void ReturnsTheResultWhenTheCircuitIsHalfOpen()
+            public void InvokesTheActionWhenTheCircuitIsHalfOpen()
             {
                 Breaker.Force(CircuitBreakerStateType.HalfOpen);
                 Assert.True(Breaker.IsHalfOpen);

--- a/Resilient.Net/CircuitBreaker/CircuitBreaker.cs
+++ b/Resilient.Net/CircuitBreaker/CircuitBreaker.cs
@@ -74,6 +74,19 @@ namespace Resilient.Net
         }
 
         /// <summary>
+        /// Execute the specified action.
+        /// </summary>
+        /// <param name="action">The action to run if the circuit is not open.</param>
+        public void Execute(Action action)
+        {
+            _currentState.Invoke(() =>
+            {
+                action.Invoke();
+                return true;
+            });
+        }
+
+        /// <summary>
         /// Execute the specified function.
         /// </summary>
         /// <param name="function">The function to execute if the circuit is not open.</param>


### PR DESCRIPTION
# The Problem

Circuit breakers won't always be used to run functions (`Func<T>`). Sometimes it makes sense to run an `Action` instead.

# The Solution

Overloading `Execute` to accept either a function or an action