### PR TITLE
Packaging and Deploying to NuGet

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,9 @@ solution: Resilient.Net.sln
 script:
   - xbuild /p:Configuration=Release Resilient.Net.sln
   - mono ./packages/xunit.runner.console.*/tools/xunit.console.exe ./Resilient.Net.Tests/bin/Release/Resilient.Net.Tests.dll
+
+deploy:
+  provider: script
+  script: scripts/package
+  on:
+    tags: true

--- a/Resilient.Net.Tests/Properties/AssemblyInfo.cs
+++ b/Resilient.Net.Tests/Properties/AssemblyInfo.cs
@@ -2,35 +2,8 @@
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Resilient.Net.Tests")]
 [assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("Resilient.Net.Tests")]
-[assembly: AssemblyCopyright("Copyright ©  2016")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("73542d63-0a50-44b4-aafe-5da4765670d6")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Resilient.Net.Tests/Resilient.Net.Tests.csproj
+++ b/Resilient.Net.Tests/Resilient.Net.Tests.csproj
@@ -74,6 +74,9 @@
     <Compile Include="CircuitBreaker\CircuitBreakerOptionsTest.cs" />
     <Compile Include="Support\TestTraceListener.cs" />
     <Compile Include="Support\TestFunctions.cs" />
+    <Compile Include="..\SolutionInfo.cs">
+      <Link>Properties\SolutionInfo.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/Resilient.Net.nuspec
+++ b/Resilient.Net.nuspec
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>resilient.net</id>
+    <version>$version$</version>
+    <title>Resilient.Net</title>
+    <authors>David Muto (pseudomuto)</authors>
+    <owners>David Muto (pseudomuto)</owners>
+    <licenseUrl>https://github.com/pseudomuto/Resilient.Net/blob/master/LICENSE</licenseUrl>
+    <projectUrl>http://github.com/pseudomuto/Resilient.Net</projectUrl>
+    <!-- <iconUrl>http://ICON_URL_HERE_OR_DELETE_THIS_LINE</iconUrl> -->
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>A library to help make applications more resilient to failures.</description>
+    <releaseNotes>Initial release.</releaseNotes>
+    <copyright>Copyright 2016</copyright>
+    <tags>Resiliency Reliability CircuitBreaker</tags>
+  </metadata>
+  <files>
+    <file src="Resilient.Net/bin/Release/*.dll" target="lib/net45" />
+    <file src="LICENSE" />
+    <file src="README.md" />
+  </files>
+</package>

--- a/Resilient.Net.sln
+++ b/Resilient.Net.sln
@@ -16,6 +16,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		CONTRIBUTING.md = CONTRIBUTING.md
 		LICENSE = LICENSE
 		xs_custom_command.png = xs_custom_command.png
+		SolutionInfo.cs = SolutionInfo.cs
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Resilient.Net.Tests", "Resilient.Net.Tests\Resilient.Net.Tests.csproj", "{73542D63-0A50-44B4-AAFE-5DA4765670D6}"

--- a/Resilient.Net/Properties/AssemblyInfo.cs
+++ b/Resilient.Net/Properties/AssemblyInfo.cs
@@ -1,39 +1,8 @@
 ﻿using System.Reflection;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
 [assembly: AssemblyTitle("Resilient.Net")]
-[assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("Resilient.Net")]
-[assembly: AssemblyCopyright("Copyright ©  2016")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("87a1d253-0cf4-4ec4-9ebd-e55f60e59f72")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyDescription("A library to help make applications more resilient to failures.")]
 
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
 [assembly: InternalsVisibleTo("Resilient.Net.Tests")]

--- a/Resilient.Net/Resilient.Net.csproj
+++ b/Resilient.Net/Resilient.Net.csproj
@@ -54,6 +54,9 @@
     <Compile Include="CircuitBreaker\CircuitBreaker.cs" />
     <Compile Include="CircuitBreaker\CircuitBreakerState.cs" />
     <Compile Include="CircuitBreaker\CircuitBreakerSwitch.cs" />
+    <Compile Include="..\SolutionInfo.cs">
+      <Link>Properties\SolutionInfo.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/SolutionInfo.cs
+++ b/SolutionInfo.cs
@@ -1,0 +1,12 @@
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyCompany("pseudomuto")]
+[assembly: AssemblyProduct("Resilient.Net")]
+[assembly: AssemblyCopyright("Copyright © pseudomuto 2016")]
+
+[assembly: AssemblyVersion("0.1.0")]
+[assembly: AssemblyFileVersion("0.1.0")]
+[assembly: AssemblyInformationalVersion("0.1.0")]
+
+[assembly: ComVisible(false)]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,0 @@
-cache:
-  - packages -> **\packages.config
-
-before_build:
-  - nuget restore

--- a/script/package
+++ b/script/package
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PRODUCT=$(sed -n 's/.*AssemblyProduct("\([^"]*\)")]/\1/p' ./SolutionInfo.cs)
+VERSION=$(sed -n 's/.*AssemblyInformationalVersion("\([^"]*\)")]/\1/p' ./SolutionInfo.cs)
+OUTPUT_DIR=./build
+
+GREEN=$(tput setaf 2)
+RESET=$(tput sgr0)
+
+function say {
+  echo -e "${GREEN}$1${RESET}"
+}
+
+function build_solution {
+  say "Building $PRODUCT v$VERSION..."
+  xbuild /p:Configuration=Release Resilient.Net.sln
+}
+
+function package_nuspec {
+  say "Packing nuspec..."
+  mkdir -p $OUTPUT_DIR
+  nuget pack Resilient.Net.nuspec -Version $VERSION -OutputDirectory $OUTPUT_DIR
+}
+
+function push_package {
+  "${NUGET_API_KEY:?NuGet API key not defined}"
+  say "Publishing $PRODUCT v$VERSION to NuGet..."
+  nuget push $OUTPUT_DIR/*.nupkg $NUGET_API_KEY
+}
+
+build_solution
+package_nuspec
+push_package


### PR DESCRIPTION
Adding some shared assembly info (product name, version, etc.) and a nuspec file that will be used to create and publish a nuget package on successful CI runs for tags.

The version will be pulled from `./SolutionInfo.cs` when generating the nupkg file.
